### PR TITLE
call prevent default on touchstart events on ios

### DIFF
--- a/src/mediator.js
+++ b/src/mediator.js
@@ -286,6 +286,9 @@ function onMouseDown(event) {
   if (!isDragging && (e.button === undefined || e.button === 0)) {
     grabbedElement = Utils.getParent(e.target, '.' + constants.wrapperClass);
     if (grabbedElement) {
+      if(/iP(ad|od|hone)/.test(navigator.userAgent) && event.type === 'touchstart') {
+        event.preventDefault();
+      }
       const containerElement = Utils.getParent(grabbedElement, '.' + constants.containerClass);
       const container = containers.filter(p => p.element === containerElement)[0];
       const dragHandleSelector = container.getOptions().dragHandleSelector;


### PR DESCRIPTION
call prevent default on touchstart events on ios to prevent containers from scrolling when dragging items around